### PR TITLE
Adds ability to resume Navigation using a Resource

### DIFF
--- a/src/Navigator.js
+++ b/src/Navigator.js
@@ -14,6 +14,22 @@ class Navigator {
       .getUrl(url)
   }
 
+  static resume (location, resource, options = {}) {
+    return new Navigator(options)
+      ._setLocation(location)
+      ._setResource(resource)
+  }
+
+  _setResource (resource) {
+    this._resource = resource
+    return this
+  }
+
+  _setLocation (location) {
+    this._location = location
+    return this
+  }
+
   constructor (options) {
     this.options = {
       ...Navigator.defaultOptions,

--- a/test/navigator/get.spec.js
+++ b/test/navigator/get.spec.js
@@ -159,4 +159,37 @@ describe('Navigator', () => {
       'Mary'
     ])
   })
+
+  it('should be able to resume navigation using a stored Resource', async () => {
+    api.onGet(baseUrl, '/users',
+      new Resource()
+        .addResource('users', [
+          createUser({ id: 'fred', name: 'Fred' }),
+          createUser({ id: 'sue', name: 'Sue' }),
+          createUser({ id: 'mary', name: 'Mary' })
+        ]))
+
+    const discoveryResource = new Resource()
+      .addLinks({
+        self: { href: '/' },
+        users: { href: '/users{?admin}', templated: true }
+      })
+
+    const result = await Navigator.resume(baseUrl, discoveryResource).get('users')
+
+    expect(result.status()).to.equal(200)
+
+    const users = result
+      .resource()
+      .getResource('users')
+
+    const names = users.map((user) =>
+      user.getProperty('name'))
+
+    expect(names).to.deep.equal([
+      'Fred',
+      'Sue',
+      'Mary'
+    ])
+  })
 })


### PR DESCRIPTION
Navigator uses  `this._location` with the `this._resource`'s links to navigate. 

As such, this solution requires a location to be passed in conjunction with the resource, with the assumption that the resource's links are all relative to its location.