### PR TITLE
Add support for PUT and DELETE requests.

### DIFF
--- a/src/Navigator.js
+++ b/src/Navigator.js
@@ -81,9 +81,19 @@ class Navigator {
     return this.postUrl(href, body, config)
   }
 
+  async put (rel, body, params = {}, config = {}) {
+    const { href } = this.resolveLink(rel, params)
+    return this.putUrl(href, body, config)
+  }
+
   async patch (rel, body, params = {}, config = {}) {
     const { href } = this.resolveLink(rel, params)
     return this.patchUrl(href, body, config)
+  }
+
+  async delete (rel, body, params = {}, config = {}) {
+    const { href } = this.resolveLink(rel, params)
+    return this.deleteUrl(href, body, config)
   }
 
   async getUrl (url, params, config) {
@@ -122,6 +132,26 @@ class Navigator {
     return this
   }
 
+  async putUrl (url, body, config) {
+    const {
+      status,
+      location,
+      body: responseBody,
+      response
+    } = await this.options.put(url, body, config)
+
+    this._status = status
+    this._location = location
+    this._response = response
+    this._resource = Resource.fromObject(responseBody)
+
+    if (this.options.followRedirects && status === 201) {
+      return this.followRedirect(config)
+    }
+
+    return this
+  }
+
   async patchUrl (url, body, config) {
     const {
       status,
@@ -138,6 +168,22 @@ class Navigator {
     if (this.options.followRedirects && status === 204) {
       return this.followRedirect(config)
     }
+
+    return this
+  }
+
+  async deleteUrl (url, body, config) {
+    const {
+      status,
+      location,
+      body: responseBody,
+      response
+    } = await this.options.delete(url, body, config)
+
+    this._status = status
+    this._location = location
+    this._response = response
+    this._resource = Resource.fromObject(responseBody)
 
     return this
   }

--- a/src/axiosOptions.js
+++ b/src/axiosOptions.js
@@ -18,8 +18,27 @@ const axiosPost = (url, body, config) =>
       response
     }))
 
+const axiosPut = (url, body, config) =>
+  axios.put(url, body, { ...config, validateStatus: () => true })
+    .then((response) => ({
+      status: response.status,
+      body: response.data,
+      location: response.config.url,
+      response
+    }))
+
 const axiosPatch = (url, body, config) =>
   axios.patch(url, body, { ...config, validateStatus: () => true })
+    .then((response) => ({
+      status: response.status,
+      body: response.data,
+      location: response.config.url,
+      response
+    }))
+
+const axiosDelete = (url, body, config) =>
+  axios.delete(url,
+    { ...config, data: body, validateStatus: () => true })
     .then((response) => ({
       status: response.status,
       body: response.data,
@@ -30,5 +49,7 @@ const axiosPatch = (url, body, config) =>
 module.exports = {
   get: axiosGet,
   post: axiosPost,
-  patch: axiosPatch
+  put: axiosPut,
+  patch: axiosPatch,
+  delete: axiosDelete
 }

--- a/test/navigator/delete.spec.js
+++ b/test/navigator/delete.spec.js
@@ -1,0 +1,75 @@
+import faker from 'faker'
+import nock from 'nock'
+import { expect } from 'chai'
+import Resource from '../../src/Resource'
+import Navigator from '../../src/Navigator'
+import * as api from '../support/api'
+
+const baseUrl = faker.internet.url()
+
+describe('Navigator', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('deletes resources in an API', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/thomas'}
+    })
+
+    api.onDelete(baseUrl, '/users/thomas', {
+      permanent: true
+    })
+
+    const discoveryResult = await Navigator.discover(baseUrl)
+    const result = await discoveryResult.delete('user', {
+      permanent: true
+    })
+
+    expect(result.status()).to.equal(204)
+  })
+
+  it('uses template params when creating resources', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/{id}', templated: true}
+    })
+
+    api.onDelete(baseUrl, '/users/thomas', {
+      permanent: true
+    })
+
+    const discoveryResult = await Navigator.discover(baseUrl)
+    const result = await discoveryResult.delete('user', {
+      permanent: true
+    }, {
+      id: 'thomas'
+    })
+
+    expect(result.status()).to.equal(204)
+  })
+
+  it('adds header options for navigation', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/thomas'}
+    })
+
+    const headers = {
+      authorization: 'some-token'
+    }
+
+    api.onDelete(baseUrl, '/users/thomas',
+      {permanent: true},
+      {headers})
+
+    api.onGet(baseUrl, '/users/thomas',
+      new Resource()
+        .addProperty('name', 'Thomas'))
+
+    const discoveryResult = await Navigator.discover(baseUrl)
+    const result = await discoveryResult.delete('user', {
+      permanent: true
+    }, {}, {headers})
+
+    expect(result.status()).to.equal(204)
+  })
+})

--- a/test/navigator/put.spec.js
+++ b/test/navigator/put.spec.js
@@ -1,0 +1,202 @@
+import faker from 'faker'
+import nock from 'nock'
+import { expect } from 'chai'
+import Resource from '../../src/Resource'
+import Navigator from '../../src/Navigator'
+import * as api from '../support/api'
+
+const baseUrl = faker.internet.url()
+
+describe('Navigator', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('replaces resources in an API', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/thomas'}
+    })
+
+    api.onPutToReplace(baseUrl, '/users/thomas', {
+      name: 'Thomas'
+    })
+
+    const discoveryResult = await Navigator.discover(baseUrl)
+    const result = await discoveryResult.put('user', {
+      name: 'Thomas'
+    })
+
+    expect(result.status()).to.equal(200)
+
+    expect(result.resource().getProperty('name'))
+      .to.deep.equal('Thomas')
+  })
+
+  it('uses template params when creating resources', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/{id}', templated: true}
+    })
+
+    api.onPutToReplace(baseUrl, '/users/thomas', {
+      name: 'Sponge'
+    })
+
+    const discoveryResult = await Navigator.discover(baseUrl)
+    const result = await discoveryResult.put('user', {
+      name: 'Sponge'
+    }, {
+      id: 'thomas'
+    })
+
+    expect(result.status()).to.equal(200)
+
+    expect(result.resource().getProperty('name'))
+      .to.deep.equal('Sponge')
+  })
+
+  it('uses absolute url when location is relative', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/thomas'}
+    })
+
+    api.onPutToReplace(baseUrl, '/users/thomas', {
+      name: 'Thomas'
+    })
+
+    const discoveryResult = await Navigator.discover(baseUrl)
+    const result = await discoveryResult.put('user', {
+      name: 'Thomas'
+    })
+
+    expect(result.status()).to.equal(200)
+
+    expect(result.resource().getProperty('name'))
+      .to.deep.equal('Thomas')
+  })
+
+  it('uses same configuration as provided on put when following redirect',
+    async () => {
+      api.onDiscover(baseUrl, {}, {
+        user: {href: '/users/thomas'}
+      })
+
+      api.onPutToCreate(baseUrl, '/users/thomas', {
+        name: 'Thomas'
+      },
+      `${baseUrl}/users/thomas`, {
+        headers: { authorization: 'Bearer 1a2b3c4d' }
+      })
+
+      api.onGet(baseUrl, '/users/thomas',
+        new Resource().addProperty('name', 'Thomas'), {
+          headers: { authorization: 'Bearer 1a2b3c4d' }
+        })
+
+      const discoveryResult = await Navigator.discover(baseUrl)
+      const result = await discoveryResult.put('user', {
+        name: 'Thomas'
+      }, {}, {
+        headers: {
+          authorization: 'Bearer 1a2b3c4d'
+        }
+      })
+
+      expect(result.status()).to.equal(200)
+
+      expect(result.resource().getProperty('name'))
+        .to.deep.equal('Thomas')
+    })
+
+  it('does not follow location headers when the status is not 201', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/thomas', templated: true}
+    })
+
+    nock(baseUrl)
+      .put('/users/thomas', {name: 'Thomas'})
+      .reply(400)
+
+    const discoveryResult = await Navigator.discover(baseUrl)
+    const result = await discoveryResult.put('user', {
+      name: 'Thomas'
+    })
+
+    expect(result.status()).to.equal(400)
+  })
+
+  it('does not follow location headers when the options say not to', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/thomas'}
+    })
+
+    api.onPutToCreate(baseUrl, '/users/thomas', {
+      name: 'Thomas'
+    }, `${baseUrl}/users/thomas`)
+
+    const discoveryResult =
+      await Navigator.discover(baseUrl, {followRedirects: false})
+    const result = await discoveryResult.put('user', {
+      name: 'Thomas'
+    })
+
+    expect(result.status()).to.equal(201)
+
+    expect(result.getHeader('location'))
+      .to.deep.equal(`${baseUrl}/users/thomas`)
+  })
+
+  it('continues the conversation even if we do not follow redirects', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/thomas'}
+    })
+
+    api.onPutToCreate(baseUrl, '/users/thomas', {
+      name: 'Thomas'
+    }, `${baseUrl}/users/thomas`)
+
+    api.onGet(baseUrl, '/users/thomas',
+      new Resource()
+        .addProperty('name', 'Thomas'))
+
+    const discoveryResult =
+      await Navigator.discover(baseUrl, {followRedirects: false})
+    const putResult = await discoveryResult.put('user', {
+      name: 'Thomas'
+    })
+    const result = await putResult.followRedirect()
+
+    expect(result.status()).to.equal(200)
+
+    expect(result.resource().getProperty('name'))
+      .to.deep.equal('Thomas')
+  })
+
+  it('adds header options for navigation', async () => {
+    api.onDiscover(baseUrl, {}, {
+      user: {href: '/users/thomas'}
+    })
+
+    const headers = {
+      authorization: 'some-token'
+    }
+
+    api.onPutToCreate(baseUrl, '/users/thomas',
+      {name: 'Thomas'},
+      `${baseUrl}/users/thomas`,
+      {headers})
+
+    api.onGet(baseUrl, '/users/thomas',
+      new Resource()
+        .addProperty('name', 'Thomas'))
+
+    const discoveryResult = await Navigator.discover(baseUrl)
+    const result = await discoveryResult.put('user', {
+      name: 'Thomas'
+    }, {}, {headers})
+
+    expect(result.status()).to.equal(200)
+
+    expect(result.resource().getProperty('name'))
+      .to.deep.equal('Thomas')
+  })
+})

--- a/test/support/api.js
+++ b/test/support/api.js
@@ -20,9 +20,26 @@ export const onPostRedirect = (url, path, body, location, { headers } = {}) =>
       Location: location
     })
 
+export const onPutToReplace = (url, path, body, { headers } = {}) =>
+  nock(url, { reqheaders: headers })
+    .put(path, body)
+    .reply(200, body)
+
+export const onPutToCreate = (url, path, body, location, { headers } = {}) =>
+  nock(url, { reqheaders: headers })
+    .put(path, body)
+    .reply(201, undefined, {
+      Location: location
+    })
+
 export const onPatchRedirect = (url, path, body, location, { headers } = {}) =>
   nock(url, { reqheaders: headers })
     .patch(path, body)
     .reply(204, undefined, {
       Location: location
     })
+
+export const onDelete = (url, path, body, { headers } = {}) =>
+  nock(url, { reqheaders: headers })
+    .delete(path, body)
+    .reply(204)


### PR DESCRIPTION
This PR adds request methods for PUT and DELETE requests. PUT requests support Location header redirects but only on 201 responses. DELETE requests don't support Location header redirects as only 201 or 3xx responses should result in redirects by the client and those response codes don't really make sense on DELETE.

Incidentally, PATCH currently redirects based on Location header which is against the HTTP spec. I would fix it but feel it should probably be a separate PR as it's a breaking change.